### PR TITLE
Fixing: Argument #1 ($array) must be of type array, null given

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3|^7.2"
     },
     "autoload": {
       "psr-4": { "ClickUp\\": "src/ClickUp/" }

--- a/src/ClickUp/Objects/AbstractObjectCollection.php
+++ b/src/ClickUp/Objects/AbstractObjectCollection.php
@@ -74,7 +74,7 @@ abstract class AbstractObjectCollection extends AbstractObject implements \Itera
 	 */
 	public function objects()
 	{
-		return $this->objects;
+		return $this->objects ?? [];
 	}
 
 	/**
@@ -82,9 +82,6 @@ abstract class AbstractObjectCollection extends AbstractObject implements \Itera
 	 */
 	public function getIterator()
 	{
-		if(! $this->objects()) {
-		    return new \ArrayIterator([]);
-		}
 		return new \ArrayIterator($this->objects());
 	}
 }

--- a/src/ClickUp/Objects/AbstractObjectCollection.php
+++ b/src/ClickUp/Objects/AbstractObjectCollection.php
@@ -82,6 +82,9 @@ abstract class AbstractObjectCollection extends AbstractObject implements \Itera
 	 */
 	public function getIterator()
 	{
+		if(! $this->objects()) {
+		    return new \ArrayIterator([]);
+		}
 		return new \ArrayIterator($this->objects());
 	}
 }


### PR DESCRIPTION
In some cases `$this->objects()` can be `null` in an `AbstractObjectCollection`.

This throws:
```
TypeError
ArrayIterator::__construct(): Argument #1 ($array) must be of type array, null given
```

This PR forces an empty array in these cases.