### PR TITLE
Protect getIterator() in case objects is null

### DIFF
--- a/src/ClickUp/Objects/AbstractObjectCollection.php
+++ b/src/ClickUp/Objects/AbstractObjectCollection.php
@@ -82,7 +82,7 @@ abstract class AbstractObjectCollection extends AbstractObject implements \Itera
 	 */
 	public function getIterator()
 	{
-		return new \ArrayIterator($this->objects());
+		return $this->objects() ? new \ArrayIterator($this->objects()) : new \EmptyIterator();
 	}
 }
 


### PR DESCRIPTION
Prevents errors such as
```
Objects returned by ClickUp\Objects\TeamMemberCollection::getIterator() must be traversable or implement interface Iterator
```